### PR TITLE
Fix length issues

### DIFF
--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -155,7 +155,9 @@ func GetCopyright(content string) string {
 
 		if strings.EqualFold(copyrightLookup, tokens[0]) {
 			cr[matchLevel2] = line
-			if re.MatchString(tokens[1]) {
+			has_multiple_tokens := len(tokens) > 1
+
+			if has_multiple_tokens && re.MatchString(tokens[1]) {
 				cr[matchLevel1] = line
 			}
 		}

--- a/pkg/modules/gem/helper.go
+++ b/pkg/modules/gem/helper.go
@@ -564,7 +564,7 @@ func isDuplicate(value string, spec Spec) bool {
 	return skip
 }
 
-//  Builds Dependency Tree from Gemfile.lock
+// Builds Dependency Tree from Gemfile.lock
 func BuildLockDependencyTree(rows []string) {
 
 	var startIndex, specPosition int

--- a/pkg/modules/yarn/handler.go
+++ b/pkg/modules/yarn/handler.go
@@ -94,7 +94,7 @@ func (m *yarn) SetRootModule(path string) error {
 }
 
 // GetRootModule return
-//root package information ex. Name, Version
+// root package information ex. Name, Version
 func (m *yarn) GetRootModule(path string) (*models.Module, error) {
 	r := reader.New(filepath.Join(path, m.metadata.Manifest[0]))
 	pkResult, err := r.ReadJson()
@@ -207,15 +207,16 @@ func (m *yarn) buildDependencies(path string, deps []dependency) ([]models.Modul
 				if name == "optionalDependencies:" {
 					continue
 				}
-
-				version := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(ar[1]), "\""), "\"")
-				if extractVersion(version) == "*" {
-					continue
-				}
-				mod.Modules[name] = &models.Module{
-					Name:     name,
-					Version:  extractVersion(version),
-					CheckSum: &models.CheckSum{Content: []byte(fmt.Sprintf("%s-%s", name, version))},
+				if len(ar) > 1 {
+					version := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(ar[1]), "\""), "\"")
+					if extractVersion(version) == "*" {
+						continue
+					}
+					mod.Modules[name] = &models.Module{
+						Name:     name,
+						Version:  extractVersion(version),
+						CheckSum: &models.CheckSum{Content: []byte(fmt.Sprintf("%s-%s", name, version))},
+					}
 				}
 			}
 		}
@@ -390,12 +391,13 @@ func appendNestedDependencies(deps []dependency) []dependency {
 				if name == "optionalDependencies:" {
 					continue
 				}
-
-				version := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(ar[1]), "\""), "\"")
-				if extractVersion(version) == "*" {
-					continue
+				if len(ar) > 1 {
+					version := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(ar[1]), "\""), "\"")
+					if extractVersion(version) == "*" {
+						continue
+					}
+					allDeps = append(allDeps, dependency{Name: name, Version: extractVersion(version)})
 				}
-				allDeps = append(allDeps, dependency{Name: name, Version: extractVersion(version)})
 			}
 		}
 	}


### PR DESCRIPTION
Issues:

```
/tmp ./spdx-sbom-generator -p ironclad/harbor -o /tmp/bom
INFO[2023-02-21T18:00:14-08:00] Starting to generate SPDX ...
INFO[2023-02-21T18:00:14-08:00] Running generator for Module Manager: `yarn` with output `/tmp/bom/bom-yarn.spdx`
INFO[2023-02-21T18:00:14-08:00] Current Language Version 1.22.19
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
spdx-sbom-generator/internal/modules/yarn.appendNestedDependencies(0xc00352a000, 0x1210, 0x1362, 0x1210, 0x1362, 0x0)
	/github/workspace/internal/modules/yarn/handler.go:372 +0x8ba
spdx-sbom-generator/internal/modules/yarn.(*yarn).ListModulesWithDeps(0xc0000b8190, 0x7ff7bfefebc9, 0xf, 0x0, 0x0, 0x1, 0x1, 0x1920720)
	/github/workspace/internal/modules/yarn/handler.go:154 +0xdf
spdx-sbom-generator/internal/modules.(*Manager).Run(0xc002f62000, 0x4, 0x1955d89)
	/github/workspace/internal/modules/modules.go:94 +0x14d
spdx-sbom-generator/internal/handler.(*spdxHandler).Run(0xc002f64000, 0x7, 0x7ff7bfefebc9)
	/github/workspace/internal/handler/spdx.go:73 +0x2ee
main.generate(0x2255c80, 0xc002f0f180, 0x0, 0x4)
	/github/workspace/cmd/generator/generator.go:105 +0x433
github.com/spf13/cobra.(*Command).execute(0x2255c80, 0xc0000b8010, 0x4, 0x4, 0x2255c80, 0xc0000b8010)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x2255c80, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
	/github/workspace/cmd/generator/generator.go:37 +0x5d
```

```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/spdx/spdx-sbom-generator/pkg/modules/yarn.appendNestedDependencies({0xc003680000, 0x1210, 0x1?})
	/tmp/spdx-sbom-generator/pkg/modules/yarn/handler.go:397 +0x752
github.com/spdx/spdx-sbom-generator/pkg/modules/yarn.(*yarn).ListModulesWithDeps(0xc000022190?, {0x7ff7bfefeba5, 0x14}, {0x16?, 0xc00315f9b0?})
	/tmp/spdx-sbom-generator/pkg/modules/yarn/handler.go:169 +0x85
github.com/spdx/spdx-sbom-generator/pkg/modules.(*Manager).Run(0xc000022230)
	/tmp/spdx-sbom-generator/pkg/modules/modules.go:102 +0x15a
github.com/spdx/spdx-sbom-generator/pkg/handler.(*spdxHandler).Run(0xc0030dc000)
	/tmp/spdx-sbom-generator/pkg/handler/spdx.go:88 +0x309
main.generate(0x1fc8ea0, {0x17e1cc2?, 0x4?, 0x4?})
	/tmp/spdx-sbom-generator/cmd/generator/generator.go:121 +0x373
github.com/spf13/cobra.(*Command).execute(0x1fc8ea0, {0xc000128010, 0x4, 0x4})
	/Users/nari.mulakala/work/gowork/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x1fc8ea0)
	/Users/nari.mulakala/work/gowork/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x39d
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/nari.mulakala/work/gowork/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
	/tmp/spdx-sbom-generator/cmd/generator/generator.go:39 +0x65
```

```

```